### PR TITLE
make docker image configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# STUPS
+/scm-source.json
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+PROJECT       ?= skoap
+VERSION       ?= $(shell git describe --tags --always --dirty)
+IMAGE         ?= pierone.stups.zalan.do/teapot/$(PROJECT)
+TAG           ?= $(VERSION)
+
 default: test.test
 
 all: clean build.linux build.osx build.win
@@ -52,9 +57,10 @@ build.service.local: prepare
 
 # docker
 build.docker: build.linux build.scmfile
-	docker build -t skoap .
-	docker tag skoap gcr.io/zalando-teapot/skoap:latest
-	gcloud docker -- push gcr.io/zalando-teapot/skoap:latest
+	docker build -t "$(IMAGE):$(TAG)" .
+
+build.push: build.docker
+	docker push "$(IMAGE):$(TAG)"
 
 # OS specific builds
 build.linux: prepare


### PR DESCRIPTION
this allows to inject `$IMAGE` and `$TAG` into the makefile.

* defaults to `pierone.stups.zalan.do/teapot/skoap:<output of git describe>` 
* adds a `.gitignore` in order to have a correct `scm-source.json`