### PR TITLE
rebase docker image onto ubuntu:16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-FROM alpine:3.3
-
-RUN apk -U add curl
-
-RUN curl https://secure-static.ztat.net/ca/zalando-service-combined.ca > \
-      /usr/share/ca-certificates/zalando-service-combined.crt
-RUN update-ca-certificates
+FROM registry.opensource.zalan.do/stups/ubuntu:16.04-35
 
 COPY entrypoint.sh /
 


### PR DESCRIPTION
Kubernetes 1.3 volume mounts have changed and this results in our entrypoint not working as expected: busybox's `update-ca-certificates` seems to ignore symlinks or similar issue.

As a quick and to avoid hacky workarounds we can just rebase on an ubuntu image which works as expected without any further change.