### PR TITLE
Use 'latest' tag in Ubuntu base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/ubuntu:16.04-45
+FROM registry.opensource.zalan.do/stups/ubuntu:latest
 
 COPY entrypoint.sh /
 


### PR DESCRIPTION
Use the `latest` Zalando Ubuntu image when building the Skoap docker image. The main advantage of this is that the fixes for any CVEs in the base image are automatically included in downstream images reducing manual updates.

An alternative would be to add a `dist-upgrade` step to the Dockerfile, but this seems excessive.

@linki @aryszka could you or the other contributors review this?